### PR TITLE
Added matrix_look_at. Added generators for matrices. Added project vector onto vector

### DIFF
--- a/cml/mathlib/mathlib.h
+++ b/cml/mathlib/mathlib.h
@@ -23,6 +23,7 @@
 #include <cml/mathlib/matrix/rotation.h>
 #include <cml/mathlib/matrix/scale.h>
 #include <cml/mathlib/matrix/projection.h>
+#include <cml/mathlib/matrix/generators.h>
 #include <cml/mathlib/matrix/misc.h>
 
 #include <cml/mathlib/quaternion/basis.h>

--- a/cml/mathlib/matrix/generators.h
+++ b/cml/mathlib/matrix/generators.h
@@ -1,0 +1,87 @@
+/* -*- C++ -*- ------------------------------------------------------------
+ @@COPYRIGHT@@
+ *-----------------------------------------------------------------------*/
+ /** @file
+   */
+
+#pragma once
+
+#ifndef	cml_mathlib_matrix_generators_h
+#define	cml_mathlib_matrix_generators_h
+
+#include <cml/matrix/fixed_compiled.h>
+
+   /** @defgroup mathlib_vector_generators Vector Generator Functions */
+
+namespace cml {
+
+	/** @addtogroup mathlib_vector_generators */
+	/*@{*/
+
+	/** @defgroup mathlib_vector_generators_basic Basic Vector Generators */
+	/*@{*/
+
+	/** Return an double-precision N-d zero vector. */
+	template<int Rows, int Cols>
+	inline matrix< double, compiled<Rows, Cols> > zero()
+	{
+		return matrix<double, compiled<Rows, Cols> >().zero();
+	}
+
+	/** Return a double-precision N-d cardinal axis by index. */
+	template<int Rows, int Cols>
+	inline matrix< double, compiled<Rows, Cols> > identity()
+	{
+		return matrix<double, compiled<Rows, Cols>>().identity();
+	}
+
+	//////////////////////////////////////////////////////////////////////////////
+	// Zero matrix
+	//////////////////////////////////////////////////////////////////////////////
+
+	/** Return the 2x2 zero matrix */
+	inline auto zero_2x2() -> decltype(zero<2, 2>()) {
+		return identity<2, 2>();
+	}
+
+	/** Return the 3x3 zero matrix */
+	inline auto zero_3x3() -> decltype(zero<3, 3>()) {
+		return zero<3, 3>();
+	}
+
+	/** Return the 4x4 zero matrix */
+	inline auto zero_4x4() -> decltype(zero<4, 4>()) {
+		return zero<4, 4>();
+	}
+
+	//////////////////////////////////////////////////////////////////////////////
+	// Identity matrix
+	//////////////////////////////////////////////////////////////////////////////
+
+	/** Return the 2x2 identity matrix */
+	inline auto identity_2x2() -> decltype(identity<2,2>()) { 
+		return identity<2, 2>(); 
+	}
+
+	/** Return the 3x3 identity matrix */
+	inline auto identity_3x3() -> decltype(identity<3, 3>()) {
+		return identity<3, 3>();
+	}
+
+	/** Return the 4x4 identity matrix */
+	inline auto identity_4x4() -> decltype(identity<4, 4>()) {
+		return identity<4, 4>();
+	}
+
+	/*@}*/
+
+	/*@}*/
+
+} // namespace cml
+
+#endif
+
+// -------------------------------------------------------------------------
+// vim:ft=cpp:sw=2
+
+

--- a/cml/mathlib/matrix/projection.h
+++ b/cml/mathlib/matrix/projection.h
@@ -238,6 +238,34 @@ template<class Sub, class E> void
 matrix_perspective_yfov_RH(writable_matrix<Sub>& m,
   E yfov, E aspect, E n, E f, ZClip z_clip);
 
+/** Build a matrix representing a perspective projection given
+ * the z-clipping range, aspect ratio, vertical field of view, and near
+ * and far clip plane positions.
+ *
+ * @throws minimum_matrix_size_error at run-time if @c m is
+ * dynamically-sized, and is not at least 4x4.  If @c m is fixed-size, the
+ * size is checked at compile-time.
+ */
+template<class Sub, class SubEye, class SubTarget, class SubUp> void
+matrix_look_at(writable_matrix<Sub>& m,
+    const readable_vector<SubEye>& position,
+    const readable_vector<SubTarget>& target,
+    const readable_vector<SubUp>& up,
+    AxisOrientation handedness,
+    ZClip z_clip);
+
+template<class Sub, class SubEye, class SubTarget, class SubUp> void
+matrix_look_at_LH(writable_matrix<Sub>& m,
+    const readable_vector<SubEye>& position,
+    const readable_vector<SubTarget>& target,
+    const readable_vector<SubUp>& up);
+
+template<class Sub, class SubEye, class SubTarget, class SubUp> void
+matrix_look_at_RH(writable_matrix<Sub>& m,
+    const readable_vector<SubEye>& position,
+    const readable_vector<SubTarget>& target,
+    const readable_vector<SubUp>& up);
+
 /*@}*/
 
 /*@}*/

--- a/cml/mathlib/matrix/projection.tpp
+++ b/cml/mathlib/matrix/projection.tpp
@@ -285,6 +285,49 @@ matrix_perspective_yfov_RH(
   matrix_perspective_yfov(m, yfov, aspect, n, f, right_handed, z_clip);
 }
 
+template<class Sub, class SubEye, class SubTarget, class SubUp> inline void
+matrix_look_at(writable_matrix<Sub>& m,
+    readable_vector<SubEye> const& position,
+    readable_vector<SubTarget> const& target,
+    readable_vector<SubUp> const up,
+    AxisOrientation handedness)
+{
+  typedef value_type_trait_of_t<Sub> value_type;
+
+    /* Checking */
+  check_affine_3D(m);
+
+  // Set matrix to identity.
+  m.identity();
+
+  value_type s = handedness == left_handed ?
+        static_cast<value_type>(1) : static_cast<value_type>(-1);
+  auto z = s * normalize(target - position);
+  auto x = normalize(cross(up, z));
+  auto y = cross(z, x);
+
+  matrix_set_basis_vectors(m,x,y,z);
+  matrix_set_translation(m,-dot(position,x),-dot(position,y),-dot(position,z));
+}
+
+template<class Sub, class SubEye, class SubTarget, class SubUp> inline void
+matrix_look_at_LH(writable_matrix<Sub>& m,
+    readable_vector<SubEye> const& position,
+    readable_vector<SubTarget> const& target,
+    readable_vector<SubUp> const up)
+{
+  matrix_look_at(m, position, target, up, left_handed);
+}
+
+template<class Sub, class SubEye, class SubTarget, class SubUp> inline void
+matrix_look_at_RH(writable_matrix<Sub>& m,
+    readable_vector<SubEye> const& position,
+    readable_vector<SubTarget> const& target,
+    readable_vector<SubUp> const up) 
+{
+  matrix_look_at(m, position, target, up, right_handed);
+}
+
 } // namespace cml
 
 #if 0

--- a/cml/mathlib/vector/misc.h
+++ b/cml/mathlib/vector/misc.h
@@ -20,6 +20,20 @@ namespace cml {
 /** @addtogroup mathlib_vector_misc */
 /*@{*/
 
+/** Project @c u onto another vector v.
+ *
+ * @throws minimum_vector_size_error at run-time if @c v or @c n has
+ * fewer than one element. If both vectors are fixed-size, the size is
+ * checked at compile-time.
+ *
+ * @throws incompatible_vector_size_error at run-time if @c v and @c n 
+ * are different sizes, and at least one is dynamically-sized.  If both
+ * vectors are fixed-size, the size is checked at compile-time.
+ */
+template<class Sub1, class Sub2> auto project_to_vector(
+  const readable_vector<Sub1>& u, const readable_vector<Sub2>& v)
+-> vector_promote_t<Sub1, Sub2>;
+
 /** Project @c v onto a hyperplane with normal @c n.
  *
  * @note @c n is assumed to be normalized.

--- a/cml/mathlib/vector/misc.tpp
+++ b/cml/mathlib/vector/misc.tpp
@@ -14,6 +14,15 @@
 namespace cml {
 
 template<class Sub1, class Sub2> inline auto
+project_to_vector(
+  const readable_vector<Sub1>& u, const readable_vector<Sub2>& v
+  )
+-> vector_promote_t<Sub1, Sub2>
+{
+  return (dot(u,v) / length_squared(v)) * v;
+}  
+
+template<class Sub1, class Sub2> inline auto
 project_to_hplane(
   const readable_vector<Sub1>& v, const readable_vector<Sub2>& n
   )


### PR DESCRIPTION
Added some functionality that was present in cml 1.0 and added a function for projecting a vector onto another vector. This could be helpful in implementing a new orthonormalise function.

Probably could do with some clean up on the comments.
