### PR TITLE
Enable cml to be used as a nested subproject.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ SET(CML_FILE_VERSION "${CML_MAJOR}_${CML_MINOR}_${CML_PATCH}")
 # Handy message:
 MESSAGE(STATUS "Building CML ${CML_RELEASE_VERSION}")
 
-SET(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMake)
+SET(CMAKE_MODULE_PATH ${CML_SOURCE_DIR}/CMake)
 
 # XXX Importing build settings for a header-only library leads to annoying
 # "Setting CML_BUILD_TYPE to T" warnings:
@@ -39,58 +39,64 @@ ELSE(WIN32)
   SET(CML_HEADER_PATH include)
 ENDIF(WIN32)
 
+# Build examples by default:
+OPTION(BUILD_EXAMPLES "Build CML examples." ON)
+SET(CML_BUILD_EXAMPLES ${BUILD_EXAMPLES})
+
 # Don't build tests by default:
 OPTION(BUILD_TESTS "Build CML tests." OFF)
 SET(CML_BUILD_TESTS ${BUILD_TESTS})
 
 # Include the source CML headers before others:
-INCLUDE_DIRECTORIES(BEFORE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
+INCLUDE_DIRECTORIES(BEFORE ${CML_SOURCE_DIR} ${CML_BINARY_DIR})
 
 # Add subdirectories to build:
 ADD_SUBDIRECTORY(cml)
-ADD_SUBDIRECTORY(examples)
+IF(CML_BUILD_EXAMPLES)
+  ADD_SUBDIRECTORY(examples)
+ENDIF(CML_BUILD_EXAMPLES)
 IF(CML_BUILD_TESTS)
   ADD_SUBDIRECTORY(tests)
 ENDIF(CML_BUILD_TESTS)
 
 # Setup configuration files:
 CONFIGURE_FILE(
-  ${CMAKE_SOURCE_DIR}/UseCML.cmake.in
-  ${CMAKE_BINARY_DIR}/UseCML.cmake
+  ${CML_SOURCE_DIR}/UseCML.cmake.in
+  ${CML_BINARY_DIR}/UseCML.cmake
   @ONLY
   )
 
 CONFIGURE_FILE(
-  ${CMAKE_SOURCE_DIR}/CMLConfig.cmake.in
-  ${CMAKE_BINARY_DIR}/CMLConfig.cmake
+  ${CML_SOURCE_DIR}/CMLConfig.cmake.in
+  ${CML_BINARY_DIR}/CMLConfig.cmake
   @ONLY
   )
 
 # XXX Importing build settings for a header-only library leads to annoying
 # "Setting CML_BUILD_TYPE to T" warnings:
 # CMAKE_EXPORT_BUILD_SETTINGS(
-#   ${CMAKE_BINARY_DIR}/CMLBuildSettings.cmake)
+#   ${CML_BINARY_DIR}/CMLBuildSettings.cmake)
 # INSTALL(FILES
-#   ${CMAKE_BINARY_DIR}/CMLBuildSettings.cmake
+#   ${CML_BINARY_DIR}/CMLBuildSettings.cmake
 #   DESTINATION .
 #   )
 
 INSTALL(FILES
-  ${CMAKE_BINARY_DIR}/UseCML.cmake
-  ${CMAKE_BINARY_DIR}/CMLConfig.cmake
+  ${CML_BINARY_DIR}/UseCML.cmake
+  ${CML_BINARY_DIR}/CMLConfig.cmake
   DESTINATION .
   )
 
 INSTALL(FILES
-  ${CMAKE_SOURCE_DIR}/doc/parameters.txt
+  ${CML_SOURCE_DIR}/doc/parameters.txt
   DESTINATION doc
   )
 
 INSTALL(FILES
-  ${CMAKE_SOURCE_DIR}/examples/simple.cpp
-  ${CMAKE_SOURCE_DIR}/examples/cml_config.h
-  ${CMAKE_SOURCE_DIR}/examples/makefile
-  ${CMAKE_SOURCE_DIR}/examples/CMakeLists.txt
+  ${CML_SOURCE_DIR}/examples/simple.cpp
+  ${CML_SOURCE_DIR}/examples/cml_config.h
+  ${CML_SOURCE_DIR}/examples/makefile
+  ${CML_SOURCE_DIR}/examples/CMakeLists.txt
   DESTINATION examples
   )
 
@@ -110,13 +116,13 @@ IF(WIN32 AND NOT UNIX)
   SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Configurable Math Libary")
   SET(CPACK_PACKAGE_VENDOR "Jesse Krebs, Demian Nave")
   SET(CPACK_PACKAGE_INSTALL_DIRECTORY "cml-${CML_FILE_VERSION}")
-  #SET(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_SOURCE_DIR}/About.txt")
-  #SET(CPACK_PACKAGE_ICON "${CMAKE_SOURCE_DIR}/<icon>")
+  #SET(CPACK_PACKAGE_DESCRIPTION_FILE "${CML_SOURCE_DIR}/About.txt")
+  #SET(CPACK_PACKAGE_ICON "${CML_SOURCE_DIR}/<icon>")
   #SET(CPACK_PACKAGE_EXECUTABLES "" "")
 
-  #SET(CPACK_RESOURCE_FILE_WELCOME "${CMAKE_SOURCE_DIR}/Welcome.txt")
-  SET(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.rtf")
-  #SET(CPACK_RESOURCE_FILE_README "${CMAKE_SOURCE_DIR}/README.txt")
+  #SET(CPACK_RESOURCE_FILE_WELCOME "${CML_SOURCE_DIR}/Welcome.txt")
+  SET(CPACK_RESOURCE_FILE_LICENSE "${CML_SOURCE_DIR}/LICENSE.rtf")
+  #SET(CPACK_RESOURCE_FILE_README "${CML_SOURCE_DIR}/README.txt")
 
   INCLUDE(CPack)
 ENDIF(WIN32 AND NOT UNIX)

--- a/cml/CMakeLists.txt
+++ b/cml/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Build a list of files relative to the CML source directory (e.g.
 # cml/vector.h):
-FILE(GLOB_RECURSE FILELIST RELATIVE ${CMAKE_SOURCE_DIR}/cml "*.h" "*.tpp")
+FILE(GLOB_RECURSE FILELIST RELATIVE ${CML_SOURCE_DIR}/cml "*.h" "*.tpp")
 LIST(REMOVE_ITEM FILELIST
   code_052306_1.h
   code_061106_1.h
@@ -21,6 +21,13 @@ FOREACH(Header ${FILELIST})
   # Install to _path, relative to the header installation directory:
   INSTALL(FILES ${Header} DESTINATION "${CML_HEADER_PATH}cml/${_path}")
 ENDFOREACH(Header)
+
+# Add an interface library if cmake is version 3.1 or newer
+IF(${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.1)
+  ADD_LIBRARY(cml INTERFACE)
+  TARGET_INCLUDE_DIRECTORIES(cml INTERFACE ${CML_SOURCE_DIR})
+  TARGET_SOURCES(cml INTERFACE ${FILE_LIST})
+ENDIF(${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.1)
 
 # --------------------------------------------------------------------------
 # vim:ft=cmake


### PR DESCRIPTION
- All paths relative to project root.
- Option to disable the example projects.
- Interface target for cmake 3.1 and newer.
